### PR TITLE
fix: GITHUB_REF to  GITHUB_REF_NAME

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ set -o xtrace
 
 if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]
 then
-    BRANCH_NAME=${GITHUB_REF}
+    BRANCH_NAME=${GITHUB_REF_NAME}
 else
     BRANCH_NAME=${GITHUB_HEAD_REF}
 fi


### PR DESCRIPTION
this change broke downloading TAs repo when workflow was triggered by push to branch
https://github.com/splunk/ta-automation-k8s-apps/pull/54/files
this is an adjustment to make it working again