### PR TITLE
fix: param for manifests branch

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,6 +23,10 @@ inputs:
   test-type:
     description: 'Type of tests to execute'
     required: true
+  k8s-manifests-branch:
+    description: 'Branch of k8s-manifests repository to use'
+    required: false
+    default: 'main'
   test-args:
     description: 'Pytest args for tests'
     required: false
@@ -85,6 +89,7 @@ runs:
     - ${{ inputs.job-name }}
     - ${{ inputs.splunk }}
     - ${{ inputs.test-type }}
+    - ${{ inputs.k8s-manifests-branch }}
     - ${{ inputs.test-args }}
     - ${{ inputs.labels }}
     - ${{ inputs.addon-name }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p sc4s-docker-registry=${15} \
     -p os-name=${16} \
     -p os-version=${17} \
-    -l="${10},test-type=${9},splunk-version=${7}" | jq -r .metadata.name`
+    -l="${10},test-type=${7},splunk-version=${7}" | jq -r .metadata.name`
 
 echo "After argo submit $?"
 echo 'WORKFLOW_NAME:' ${WORKFLOW_NAME}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,15 +31,16 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p job-name=${5} \
     -p splunk-version=${6} \
     -p test-type=${7} \
-    -p pytest-args="${8}" \
-    -p addon-name=${10} \
-    -p vendor-version=${11}\
-    -p sc4s-version=${12} \
-    -p install-java=${13} \
-    -p sc4s-docker-registry=${14} \
-    -p os-name=${15} \
-    -p os-version=${16} \
-    -l="${9},test-type=${7},splunk-version=${6}" | jq -r .metadata.name`
+    -p k8s-manifests-branch="${8}" \
+    -p pytest-args="${9}" \
+    -p addon-name=${11} \
+    -p vendor-version=${12}\
+    -p sc4s-version=${13} \
+    -p install-java=${14} \
+    -p sc4s-docker-registry=${15} \
+    -p os-name=${16} \
+    -p os-version=${17} \
+    -l="${10},test-type=${9},splunk-version=${7}" | jq -r .metadata.name`
 
 echo "After argo submit $?"
 echo 'WORKFLOW_NAME:' ${WORKFLOW_NAME}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p sc4s-docker-registry=${15} \
     -p os-name=${16} \
     -p os-version=${17} \
-    -l="${10},test-type=${7},splunk-version=${7}" | jq -r .metadata.name`
+    -l="${10},test-type=${7},splunk-version=${6}" | jq -r .metadata.name`
 
 echo "After argo submit $?"
 echo 'WORKFLOW_NAME:' ${WORKFLOW_NAME}


### PR DESCRIPTION
PR adds a parameter to specify [splunk/ta-automation-k8s-manifests](https://github.com/splunk/ta-automation-k8s-manifests) branch used in a workflow. It should make testing easier. The default branch is main

Tested with:
https://github.com/splunk/splunk-add-on-for-apache-web-server/actions/runs/3516036691/jobs/5892119888