### PR TITLE
fix: deprication of delay-destroy warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,12 @@ on:
       - "main"
       - "develop"
 
+permissions:
+  contents: write
+  packages: write
+  pull-requests: read
+  statuses: write
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/action.yaml
+++ b/action.yaml
@@ -1,3 +1,4 @@
+
 #   ########################################################################
 #   Copyright 2021 Splunk Inc.
 #
@@ -80,7 +81,7 @@ outputs:
     description: 'Name of workflow triggered'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/splunk/wfe-test-runner-action/wfe-test-runner-action:v1.6.9'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.workflow-tmpl-name }}
     - ${{ inputs.workflow-template-ns }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,9 +24,13 @@ else
     BRANCH_NAME=${GITHUB_HEAD_REF}
 fi
 
+if [[ ${3} ]]
+then
+  echo "::warning title=Delay destroy not supported::Delay destroy is deprecated, please update your reusable workflow version"
+fi
 WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.argoproj.io/workflow-template=${1} --argo-base-href '' \
     -p ci-repository-url="https://github.com/${GITHUB_REPOSITORY}.git" \
-    -p ci-commit-sha=${BRANCH_NAME} -p delay-destroy=${3} \
+    -p ci-commit-sha=${BRANCH_NAME} \
     -p addon-url="${4}" \
     -p job-name=${5} \
     -p splunk-version=${6} \


### PR DESCRIPTION
Do not merge, needs to be backported to 1.6.10

Tested here:
https://github.com/splunk/splunk-add-on-for-microsoft-sysmon/actions/runs/9064069902/job/24901584343