### PR TITLE
fix: upgrade workflow-engine-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/splunk/workflow-engine-base:4.0.0
+FROM ghcr.io/splunk/workflow-engine-base:4.1.0
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yaml
+++ b/action.yaml
@@ -80,7 +80,7 @@ outputs:
     description: 'Name of workflow triggered'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/splunk/wfe-test-runner-action/wfe-test-runner-action:v5.0.0'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.workflow-tmpl-name }}
     - ${{ inputs.workflow-template-ns }}


### PR DESCRIPTION
This PR contains update [workflow-engine-images from v4.0.0 to v4.1.0](https://cd.splunkdev.com/core-ee/workflow-engine/workflow-engine-images/-/merge_requests/38)
Underneath it bumps kubectl version from `v1.22.0` to `v1.28.0`, such that --retries flag is available while copying diag files in the pipeline

Jira: https://splunk.atlassian.net/browse/ADDON-69486
Test runs: 

- https://github.com/splunk/splunk-add-on-for-java-management-extensions/actions/runs/9349620640/job/25731672833
- https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/9349120039