### PR TITLE
chore: add proper log message when argo logs yields with EOF error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,4 +47,4 @@ echo "After argo submit $?"
 echo 'WORKFLOW_NAME:' ${WORKFLOW_NAME}
 echo "workflow-name=$(echo $WORKFLOW_NAME)" >> $GITHUB_OUTPUT
 
-argo logs --follow ${WORKFLOW_NAME} -n ${2}
+argo logs --follow ${WORKFLOW_NAME} -n ${2} || echo "... There was an error fetching the logs. The workflow is still in progress, and the tests are still running. The results will be available in the Test Report step. Please wait for the workflow to complete. ..."


### PR DESCRIPTION
This PR provides proper log message when the EOF error appears while performing `argo logs --follow` operation. It caused a lot of confusion among developers, since it looked like the tests stopped being performed (although they were still in progress). The developers used to unnecessarily re-trigger tests in this case. 

The message should be enough. Optionally, we could also add one or two retries  of `argo logs --follow` while getting EOF error (https://grpc.github.io/grpc/core/md_doc_statuscodes.html)