### PR TITLE
feat: upgrade tests

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -75,12 +75,16 @@ inputs:
     description: 'Browser type for UI tests'
     required: false
     default: ''
+  ta-upgrade-version:
+    required: false
+    description: 'Initial version of the TA for upgrade tests'
+    default: ''
 outputs:
   workflow-name: # id of output
     description: 'Name of workflow triggered'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/splunk/wfe-test-runner-action/wfe-test-runner-action:v5.0.2'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.workflow-tmpl-name }}
     - ${{ inputs.workflow-template-ns }}
@@ -99,3 +103,4 @@ runs:
     - ${{ inputs.os-name }}
     - ${{ inputs.os-version }}
     - ${{ inputs.test-browser }}
+    - ${{ inputs.ta-upgrade-version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,7 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p os-name=${15} \
     -p os-version=${16} \
     -p test-browser=${17} \
+    -p ta-upgrade-version=${18} \
     -l="${9},test-type=${6},splunk-version=${5}" | jq -r .metadata.name`
 
 echo "After argo submit $?"


### PR DESCRIPTION
TA-> TA Upgrade implementation [ADDON-73792](https://splunk.atlassian.net/browse/ADDON-73792)

This pull request introduces a new feature to our CI/CD pipeline, focusing on automating upgrade testing for Technology Add-ons (TA). The goal is to streamline the release process by incorporating scalable and user-friendly solutions capable of executing upgrade scenarios

Key Features:
Automated Upgrade Testing: Introduces jobs for upgrade testing within the GitHub CI/CD pipeline.

Flexible Version Testing: Allows users to provide multiple TA versions on which upgrade tests should be executed. In this repo, ta_upgrade_version parameter is responsible for passing the info about versions being tested. Also, both GitHub and Splunkbase releases are supported, depending on the format of the version string provided:

vX.X.X - for GitHub releases
X.X.X - for Splunkbase releases
additionally, latest can be passed to use the latest version from GitHub
example run - https://github.com/splunk/splunk-add-on-for-amazon-web-services/actions/runs/12045945177

Part of 
https://github.com/splunk/ta-automation-app-of-apps/pull/27
https://github.com/splunk/ta-automation-k8s-manifests/pull/102
https://github.com/splunk/addonfactory-workflow-addon-release/pull/344
