### PR TITLE
feat: add python-version parameter #29

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,7 +82,6 @@ inputs:
   python-version:
     description: 'Python version to use for tests'
     required: false
-    default: '3.7'
 outputs:
   workflow-name: # id of output
     description: 'Name of workflow triggered'

--- a/action.yaml
+++ b/action.yaml
@@ -82,6 +82,7 @@ inputs:
   python-version:
     description: 'Python version to use for tests'
     required: false
+    default: ''
 outputs:
   workflow-name: # id of output
     description: 'Name of workflow triggered'

--- a/action.yaml
+++ b/action.yaml
@@ -79,12 +79,16 @@ inputs:
     required: false
     description: 'Initial version of the TA for upgrade tests'
     default: ''
+  python-version:
+    description: 'Python version to use for tests'
+    required: false
+    default: '3.7'
 outputs:
   workflow-name: # id of output
     description: 'Name of workflow triggered'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/splunk/wfe-test-runner-action/wfe-test-runner-action:v5.1.0'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.workflow-tmpl-name }}
     - ${{ inputs.workflow-template-ns }}
@@ -104,3 +108,4 @@ runs:
     - ${{ inputs.os-version }}
     - ${{ inputs.test-browser }}
     - ${{ inputs.ta-upgrade-version }}
+    - ${{ inputs.python-version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,7 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p os-version=${16} \
     -p test-browser=${17} \
     -p ta-upgrade-version=${18} \
+    -p python-version=${19} \
     -l="${9},test-type=${6},splunk-version=${5}" | jq -r .metadata.name`
 
 echo "After argo submit $?"


### PR DESCRIPTION
This PR introduces new optional parameter to the action to control the version of Python used across testing environments.
Related app-of-apps PR: https://github.com/splunk/ta-automation-app-of-apps/pull/29

Tests:
https://github.com/splunk/splunk-add-on-for-microsoft-office-365/actions/runs/16443769270

Backward compatibility tests:
https://github.com/splunk/splunk-add-on-for-google-workspace/pull/634

Note:
This change is not affecting current workflows execution and can be safely used with already released reusable workflow versions.