### PR TITLE
ci: migrate GH_TOKEN_ADMIN to GitHub App token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,13 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Install yq
         run: sudo snap install yq
       - name: Set up QEMU
@@ -88,7 +95,7 @@ jobs:
 
       - uses: splunk/semantic-release-action@v1.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
@@ -101,9 +108,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: splunk/addonfactory-update-semver@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           git_committer_name: ${{ secrets.SA_GH_USER_NAME }}
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}


### PR DESCRIPTION
## Summary
- Replace `GH_TOKEN_ADMIN` (PAT) with short-lived installation tokens via `actions/create-github-app-token@v3`.
- Add a token generation step to the `build_action` and `update-semver` jobs (each job needs its own token since tokens are revoked at job end).
- Update `splunk/semantic-release-action@v1.3` and `splunk/addonfactory-update-semver@v1` to consume `steps.app-token.outputs.token` via `GITHUB_TOKEN`.


Made with [Cursor](https://cursor.com)