### PR TITLE
feat: add server-conf-python-version input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -92,7 +92,7 @@ outputs:
     description: 'Name of workflow triggered'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/splunk/wfe-test-runner-action/wfe-test-runner-action:v5.1.1'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.workflow-tmpl-name }}
     - ${{ inputs.workflow-template-ns }}

--- a/action.yaml
+++ b/action.yaml
@@ -83,6 +83,10 @@ inputs:
     description: 'Python version to use for tests'
     required: false
     default: ''
+  server-conf-python-version:
+    description: 'Value to set as python.version in server.conf [general] before tests'
+    required: false
+    default: ''
 outputs:
   workflow-name: # id of output
     description: 'Name of workflow triggered'
@@ -109,3 +113,4 @@ runs:
     - ${{ inputs.test-browser }}
     - ${{ inputs.ta-upgrade-version }}
     - ${{ inputs.python-version }}
+    - ${{ inputs.server-conf-python-version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,7 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p test-browser=${17} \
     -p ta-upgrade-version=${18} \
     -p python-version=${19} \
+    -p server-conf-python-version=${20} \
     -l="${9},test-type=${6},splunk-version=${5}" | jq -r .metadata.name`
 
 echo "After argo submit $?"


### PR DESCRIPTION
- Adds `server-conf-python-version` input to `action.yaml` — passed as positional argument `$20` to `argo submit`
- Replaces pre-built Docker image (`v5.1.1`) with `Dockerfile` so the updated `entrypoint.sh` is actually executed

## Why

The `server-conf-python-version` value needs to flow from the GitHub Actions matrix through Argo Workflows down to `deploy-splunk-and-addon.sh`. Without this change, the value was accepted by `action.yaml` but never forwarded to Argo — the pre-built image `v5.1.1` was used instead of the updated `entrypoint.sh`.

## Test plan

- [x] Verify that `argo submit` receives `-p server-conf-python-version=<value>` when input is set
- [x] Verify that `argo submit` receives `-p server-conf-python-version=` (empty) when input is not set
- [x] Verify existing test types unaffected when `server-conf-python-version` is empty