### PR TITLE
feat: add server-conf-python-version input (signed, replaces #49)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -92,7 +92,7 @@ outputs:
     description: 'Name of workflow triggered'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/splunk/wfe-test-runner-action/wfe-test-runner-action:v5.1.1'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.workflow-tmpl-name }}
     - ${{ inputs.workflow-template-ns }}

--- a/action.yaml
+++ b/action.yaml
@@ -83,6 +83,10 @@ inputs:
     description: 'Python version to use for tests'
     required: false
     default: ''
+  server-conf-python-version:
+    description: 'Value to set as python.version in server.conf [general] before tests'
+    required: false
+    default: ''
 outputs:
   workflow-name: # id of output
     description: 'Name of workflow triggered'
@@ -109,3 +113,4 @@ runs:
     - ${{ inputs.test-browser }}
     - ${{ inputs.ta-upgrade-version }}
     - ${{ inputs.python-version }}
+    - ${{ inputs.server-conf-python-version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,7 @@ WORKFLOW_NAME=`argo submit -v -o json --from wftmpl/${1} -n ${2} -l workflows.ar
     -p test-browser=${17} \
     -p ta-upgrade-version=${18} \
     -p python-version=${19} \
+    -p server-conf-python-version=${20} \
     -l="${9},test-type=${6},splunk-version=${5}" | jq -r .metadata.name`
 
 echo "After argo submit $?"


### PR DESCRIPTION
Re-creates #49 with GPG-signed commits (main is protected requiring signed commits; #49's commits were unsigned). Same diff, author preserved as original (Dariusz Karas), commits re-signed with my key via interactive rebase (`git rebase --exec 'git commit --amend --no-edit -S'`).

Supersedes #49 — closing that one in favor of this branch to keep signed history.

## Original description
- Pass `server-conf-python-version` as $20 to argo submit so `deploy-splunk-and-addon.sh` can set `python.version` in `server.conf` before tests run.
- Build Docker image from local Dockerfile instead of pre-built v5.1.1 so the updated `entrypoint.sh` is actually used.